### PR TITLE
add-num-pages

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -6,12 +6,13 @@ import (
 	"compress/zlib"
 	"encoding/binary"
 	"fmt"
-	"github.com/pkg/errors"
 	"io"
 	"io/ioutil"
 	"math"
 	"os"
 	"strconv"
+
+	"github.com/pkg/errors"
 )
 
 type PdfReader struct {
@@ -66,6 +67,10 @@ func NewPdfReader(filename string) (*PdfReader, error) {
 	}
 
 	return parser, nil
+}
+
+func (this *PdfReader) NumPages() int {
+	return len(this.pages)
 }
 
 func (this *PdfReader) init() error {


### PR DESCRIPTION
Adds a method to the PdfReader to be able to retrieve the number of pages (without calling GetPageSizes).